### PR TITLE
fix(typescript): fix typescript entry path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A fast C++ implementation with JSI binding of MD5 for React Native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
-  "types": "lib/typescript/src/index.d.ts",
+  "types": "lib/typescript/index.d.ts",
   "react-native": "src/index",
   "source": "src/index",
   "files": [


### PR DESCRIPTION
Path in `tsconfig.json` refers directly to the entry point `"./src/index"`, so the types in `package.json` should not have subfolder

Fix types path in `package.json`,
`"types": "lib/typescript/src/index.d.ts"` -> `"types": "lib/typescript/index.d.ts"`
fix https://github.com/craftzdog/react-native-quick-md5/issues/4