### PR TITLE
Skip initialization when the void pointer is returned

### DIFF
--- a/android/src/main/java/com/reactnativequickmd5/QuickMd5Module.java
+++ b/android/src/main/java/com/reactnativequickmd5/QuickMd5Module.java
@@ -1,5 +1,7 @@
 package com.reactnativequickmd5;
 
+import android.util.Log;
+
 import androidx.annotation.NonNull;
 
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -11,7 +13,7 @@ class QuickMd5Module extends ReactContextBaseJavaModule {
     System.loadLibrary("quickmd5");
   }
 
-  private static native void initialize(long jsiPtr, String docDir);
+  private static native void initialize(long jsiPtr);
   private static native void destruct();
 
   public QuickMd5Module(ReactApplicationContext reactContext) {
@@ -28,9 +30,13 @@ class QuickMd5Module extends ReactContextBaseJavaModule {
   public void initialize() {
     super.initialize();
 
-    QuickMd5Module.initialize(
-      this.getReactApplicationContext().getJavaScriptContextHolder().get(),
-      this.getReactApplicationContext().getFilesDir().getAbsolutePath());
+    long contextPointer = this.getReactApplicationContext().getJavaScriptContextHolder().get();
+
+    if (contextPointer == 0) {
+      Log.e("QuickMd5", "Initialization failed due to void pointer");
+    } else {
+      QuickMd5Module.initialize(contextPointer);
+    }
   }
 
   @Override

--- a/android/src/main/java/com/reactnativequickmd5/QuickMd5Package.java
+++ b/android/src/main/java/com/reactnativequickmd5/QuickMd5Package.java
@@ -7,7 +7,6 @@ import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.uimanager.ViewManager;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -16,7 +15,7 @@ public class QuickMd5Package implements ReactPackage {
   @NonNull
   @Override
   public List<NativeModule> createNativeModules(@NonNull ReactApplicationContext reactContext) {
-    return Arrays.<NativeModule>asList(new QuickMd5Module(reactContext));
+    return Collections.singletonList(new QuickMd5Module(reactContext));
   }
 
   @NonNull


### PR DESCRIPTION
If we run the application in debug mode and then connect the React Native Debugger to the application the javascript holder pointer always returns 0 thus it can't inject the native way of calculating md5. Of course, inside the app, I have to supply it with some polyfill to be able to use the module but this is not the point of this pull request.