### PR TITLE
fix crash on install jsi module

### DIFF
--- a/ios/QuickMd5.mm
+++ b/ios/QuickMd5.mm
@@ -23,7 +23,9 @@ RCT_EXPORT_MODULE()
     return;
   }
 
-  installMd5(*(facebook::jsi::Runtime *)cxxBridge.runtime);
+  [bridge dispatchBlock:^{
+    installMd5(*(facebook::jsi::Runtime *)cxxBridge.runtime);
+  } queue:RCTJSThread];
 }
 
 - (void)invalidate {


### PR DESCRIPTION
unsafely accessing the JS thread from the main thread
#https://github.com/facebook/hermes/issues/1011
#https://github.com/craftzdog/react-native-quick-base64/issues/26