### PR TITLE
chore: add parentheses to fix -Wbitwise warning

### DIFF
--- a/cpp/md5.cpp
+++ b/cpp/md5.cpp
@@ -55,11 +55,11 @@ documentation and/or software.
  
 // F, G, H and I are basic MD5 functions.
 inline MD5::uint4 MD5::F(uint4 x, uint4 y, uint4 z) {
-  return x&y | ~x&z;
+  return (x&y) | (~x&z);
 }
  
 inline MD5::uint4 MD5::G(uint4 x, uint4 y, uint4 z) {
-  return x&z | y&~z;
+  return (x&z) | (y&~z);
 }
  
 inline MD5::uint4 MD5::H(uint4 x, uint4 y, uint4 z) {


### PR DESCRIPTION
During build (since RN73) we are getting a heavy amount of warnings generated. I am just going from package to package fixing them.

```
C/C++: /Users/xx/xx/xxx-app/node_modules/react-native-quick-md5/cpp/md5.cpp:58:11: warning: '&' within '|' [-Wbitwise-op-parentheses]
C/C++:   return x&y | ~x&z;
C/C++:          ~^~ ~
C/C++: /Users/xx/xx/xxx-app/node_modules/react-native-quick-md5/cpp/md5.cpp:58:11: note: place parentheses around the '&' expression to silence this warning
C/C++:   return x&y | ~x&z;
C/C++:           ^
C/C++:          (  )
C/C++: /Users/xx/xx/xxx-app/node_modules/react-native-quick-md5/cpp/md5.cpp:58:18: warning: '&' within '|' [-Wbitwise-op-parentheses]
C/C++:   return x&y | ~x&z;
C/C++:              ~ ~~^~
C/C++: /Users/xx/xx/xxx-app/node_modules/react-native-quick-md5/cpp/md5.cpp:58:18: note: place parentheses around the '&' expression to silence this warning
C/C++:   return x&y | ~x&z;
C/C++:                  ^
C/C++:                (   )
C/C++: /Users/xx/xx/xxx-app/node_modules/react-native-quick-md5/cpp/md5.cpp:62:11: warning: '&' within '|' [-Wbitwise-op-parentheses]
C/C++:   return x&z | y&~z;
C/C++:          ~^~ ~
C/C++: /Users/xx/xx/xxx-app/node_modules/react-native-quick-md5/cpp/md5.cpp:62:11: note: place parentheses around the '&' expression to silence this warning
C/C++:   return x&z | y&~z;
C/C++:           ^
C/C++:          (  )
C/C++: /Users/xx/xx/xxx-app/node_modules/react-native-quick-md5/cpp/md5.cpp:62:17: warning: '&' within '|' [-Wbitwise-op-parentheses]
C/C++:   return x&z | y&~z;
C/C++:              ~ ~^~~
C/C++: /Users/xx/xx/xxx-app/node_modules/react-native-quick-md5/cpp/md5.cpp:62:17: note: place parentheses around the '&' expression to silence this warning
C/C++:   return x&z | y&~z;
C/C++:                 ^
C/C++:                (   )
C/C++: 4 warnings generated.
```