### PR TITLE
fix: bring android 16kb support

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -55,7 +55,8 @@ android {
         cmake {
             cppFlags "-O2 -frtti -fexceptions -Wall -fstack-protector-all"
             abiFilters 'x86', 'x86_64', 'armeabi-v7a', 'arm64-v8a'
-            arguments "-DNODE_MODULES_DIR=${nodeModules}"
+            arguments "-DNODE_MODULES_DIR=${nodeModules}",
+                      "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
         }
     }
     


### PR DESCRIPTION
PR adding support for Android 16kb builds (see [android-developers.googleblog.com/2025/05/prepare-play-apps-for-devices-with-16kb-page-size.html?utm_source=email&utm_medium=newsletter&utm_campaign=Play-june25](https://android-developers.googleblog.com/2025/05/prepare-play-apps-for-devices-with-16kb-page-size.html?utm_source=email&utm_medium=newsletter&utm_campaign=Play-june25) and e.g. https://github.com/mrousavy/react-native-vision-camera/pull/3543