### PR TITLE
fix: support for RN 0.80.0 or newer

### DIFF
--- a/react-native-quick-md5.podspec
+++ b/react-native-quick-md5.podspec
@@ -17,5 +17,5 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm}", "cpp/**/*.{h,cpp}"
   
 
-  s.dependency "React-Core"
+  install_modules_dependencies(s)
 end


### PR DESCRIPTION
This will PR is adding support to use the new way of installing RN dependencies for an iOS lib.

Fixes the following error:
```
Undefined symbols for architecture arm64:
  "facebook::jsi::Value::~Value()", referenced from:
      void facebook::jsi::Object::setProperty<facebook::jsi::Function>(facebook::jsi::Runtime&, facebook::jsi::String const&, facebook::jsi::Function&&) const in quick-md5.o
      void facebook::jsi::Object::setProperty<facebook::jsi::Function>(facebook::jsi::Runtime&, facebook::jsi::String const&, facebook::jsi::Function&&) const in quick-md5.o
      facebook::jsi::Value::Value(facebook::jsi::Runtime&, facebook::jsi::Object const&) in quick-md5.o
  "facebook::jsi::Value::asObject(facebook::jsi::Runtime&) const &", referenced from:
      md5_valueToString(facebook::jsi::Runtime&, facebook::jsi::Value const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>*) in quick-md5.o
  "facebook::jsi::Value::asString(facebook::jsi::Runtime&) const &", referenced from:
      md5_valueToString(facebook::jsi::Runtime&, facebook::jsi::Value const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>*) in quick-md5.o
ld: symbol(s) not found for architecture arm64
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```