### PR TITLE
support RN 0.81

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.9.0)
 
 set (PACKAGE_NAME "react-native-quick-md5")
 set (CMAKE_VERBOSE_MAKEFILE ON)
-set (CMAKE_CXX_STANDARD 14)
+set (CMAKE_CXX_STANDARD 17)
 
 file(TO_CMAKE_PATH "${NODE_MODULES_DIR}/react-native/ReactCommon/jsi/jsi/jsi.cpp" libPath)
 


### PR DESCRIPTION
Hi! Thank you for this library!
After upgrading to RN 0.81 I've got an error. Updating to `cxx17` fixed for me

```
> Task :react-native-quick-md5:buildCMakeRelWithDebInfo[arm64-v8a] FAILED
C/C++: ninja: Entering directory `/Users/User/node_modules/react-native-quick-md5/android/.cxx/RelWithDebInfo/3xx3v2w6/arm64-v8a'
C/C++: /Users/ilia/Library/Android/sdk/ndk/27.1.12297006/toolchains/llvm/prebuilt/darwin-x86_64/bin/clang++ --target=aarch64-none-linux-android21 --sysroot=/Users/ilia/Library/Android/sdk/ndk/27.1.12297006/toolchains/llvm/prebuilt/darwin-x86_64/sysroot -Dquickmd5_EXPORTS -I/Users/User/node_modules/react-native-quick-md5/android/../cpp -I/Users/User/node_modules/react-native/React -I/Users/User/node_modules/react-native/React/Base -I/Users/User/node_modules/react-native/ReactCommon/jsi -g -DANDROID -fdata-sections -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes -D__BIONIC_NO_PAGE_SIZE_MACRO -D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security  -O2 -frtti -fexceptions -Wall -fstack-protector-all -O2 -g -DNDEBUG -fPIC -std=gnu++14 -MD -MT CMakeFiles/quickmd5.dir/cpp-adapter.cpp.o -MF CMakeFiles/quickmd5.dir/cpp-adapter.cpp.o.d -o CMakeFiles/quickmd5.dir/cpp-adapter.cpp.o -c /Users/User/node_modules/react-native-quick-md5/android/cpp-adapter.cpp
C/C++: In file included from /Users/User/node_modules/react-native-quick-md5/android/cpp-adapter.cpp:2:
C/C++: In file included from /Users/User/node_modules/react-native-quick-md5/android/../cpp/quick-md5.h:1:
C/C++: In file included from /Users/User/node_modules/react-native/ReactCommon/jsi/jsi/jsilib.h:10:
C/C++: /Users/User/node_modules/react-native/ReactCommon/jsi/jsi/jsi.h:79:5: error: no matching function for call to 'snprintf'
C/C++:    79 |     std::snprintf(
C/C++:       |     ^~~~~~~~~~~~~
C/C++: /Users/ilia/Library/Android/sdk/ndk/27.1.12297006/toolchains/llvm/prebuilt/darwin-x86_64/sysroot/usr/include/stdio.h:286:5: note: candidate function not viable: 1st argument ('const value_type *' (aka 'const char *')) would lose const qualifier
C/C++:   286 | int snprintf(char* __BIONIC_COMPLICATED_NULLNESS __buf, size_t __size, const char* _Nonnull __fmt, ...) __printflike(3, 4);
C/C++:       |     ^        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
C/C++: /Users/ilia/Library/Android/sdk/ndk/27.1.12297006/toolchains/llvm/prebuilt/darwin-x86_64/sysroot/usr/include/bits/fortify/stdio.h:77:5: note: candidate function not viable: 1st argument ('const value_type *' (aka 'const char *')) would lose const qualifier
C/C++:    77 | int snprintf(char* const __BIONIC_COMPLICATED_NULLNESS __pass_object_size dest, size_t size, const char* _Nonnull format, ...)
C/C++:       |     ^        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
C/C++: 1 error generated.
C/C++: /Users/ilia/Library/Android/sdk/ndk/27.1.12297006/toolchains/llvm/prebuilt/darwin-x86_64/bin/clang++ --target=aarch64-none-linux-android21 --sysroot=/Users/ilia/Library/Android/sdk/ndk/27.1.12297006/toolchains/llvm/prebuilt/darwin-x86_64/sysroot -Dquickmd5_EXPORTS -I/Users/User/node_modules/react-native-quick-md5/android/../cpp -I/Users/User/node_modules/react-native/React -I/Users/User/node_modules/react-native/React/Base -I/Users/User/node_modules/react-native/ReactCommon/jsi -g -DANDROID -fdata-sections -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes -D__BIONIC_NO_PAGE_SIZE_MACRO -D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security  -O2 -frtti -fexceptions -Wall -fstack-protector-all -O2 -g -DNDEBUG -fPIC -std=gnu++14 -MD -MT CMakeFiles/quickmd5.dir/Users/User/node_modules/react-native-quick-md5/cpp/quick-md5.cpp.o -MF CMakeFiles/quickmd5.dir/Users/User/node_modules/react-native-quick-md5/cpp/quick-md5.cpp.o.d -o CMakeFiles/quickmd5.dir/Users/User/node_modules/react-native-quick-md5/cpp/quick-md5.cpp.o -c /Users/User/node_modules/react-native-quick-md5/cpp/quick-md5.cpp
C/C++: In file included from /Users/User/node_modules/react-native-quick-md5/cpp/quick-md5.cpp:1:
C/C++: In file included from /Users/User/node_modules/react-native-quick-md5/cpp/quick-md5.h:1:
C/C++: In file included from /Users/User/node_modules/react-native/ReactCommon/jsi/jsi/jsilib.h:10:
C/C++: /Users/User/node_modules/react-native/ReactCommon/jsi/jsi/jsi.h:79:5: error: no matching function for call to 'snprintf'
C/C++:    79 |     std::snprintf(
C/C++:       |     ^~~~~~~~~~~~~
C/C++: /Users/ilia/Library/Android/sdk/ndk/27.1.12297006/toolchains/llvm/prebuilt/darwin-x86_64/sysroot/usr/include/stdio.h:286:5: note: candidate function not viable: 1st argument ('const value_type *' (aka 'const char *')) would lose const qualifier
C/C++:   286 | int snprintf(char* __BIONIC_COMPLICATED_NULLNESS __buf, size_t __size, const char* _Nonnull __fmt, ...) __printflike(3, 4);
C/C++:       |     ^        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
C/C++: /Users/ilia/Library/Android/sdk/ndk/27.1.12297006/toolchains/llvm/prebuilt/darwin-x86_64/sysroot/usr/include/bits/fortify/stdio.h:77:5: note: candidate function not viable: 1st argument ('const value_type *' (aka 'const char *')) would lose const qualifier
C/C++:    77 | int snprintf(char* const __BIONIC_COMPLICATED_NULLNESS __pass_object_size dest, size_t size, const char* _Nonnull format, ...)
C/C++:       |     ^        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
C/C++: 1 error generated.
C/C++: /Users/ilia/Library/Android/sdk/ndk/27.1.12297006/toolchains/llvm/prebuilt/darwin-x86_64/bin/clang++ --target=aarch64-none-linux-android21 --sysroot=/Users/ilia/Library/Android/sdk/ndk/27.1.12297006/toolchains/llvm/prebuilt/darwin-x86_64/sysroot -Dquickmd5_EXPORTS -I/Users/User/node_modules/react-native-quick-md5/android/../cpp -I/Users/User/node_modules/react-native/React -I/Users/User/node_modules/react-native/React/Base -I/Users/User/node_modules/react-native/ReactCommon/jsi -g -DANDROID -fdata-sections -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes -D__BIONIC_NO_PAGE_SIZE_MACRO -D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security  -O2 -frtti -fexceptions -Wall -fstack-protector-all -O2 -g -DNDEBUG -fPIC -std=gnu++14 -MD -MT CMakeFiles/quickmd5.dir/Users/User/node_modules/react-native/ReactCommon/jsi/jsi/jsi.cpp.o -MF CMakeFiles/quickmd5.dir/Users/User/node_modules/react-native/ReactCommon/jsi/jsi/jsi.cpp.o.d -o CMakeFiles/quickmd5.dir/Users/User/node_modules/react-native/ReactCommon/jsi/jsi/jsi.cpp.o -c /Users/User/node_modules/react-native/ReactCommon/jsi/jsi/jsi.cpp
C/C++: In file included from /Users/User/node_modules/react-native/ReactCommon/jsi/jsi/jsi.cpp:15:
C/C++: In file included from /Users/User/node_modules/react-native/ReactCommon/jsi/jsi/instrumentation.h:16:
C/C++: /Users/User/node_modules/react-native/ReactCommon/jsi/jsi/jsi.h:79:5: error: no matching function for call to 'snprintf'
C/C++:    79 |     std::snprintf(
C/C++:       |     ^~~~~~~~~~~~~
C/C++: /Users/ilia/Library/Android/sdk/ndk/27.1.12297006/toolchains/llvm/prebuilt/darwin-x86_64/sysroot/usr/include/stdio.h:286:5: note: candidate function not viable: 1st argument ('const value_type *' (aka 'const char *')) would lose const qualifier
C/C++:   286 | int snprintf(char* __BIONIC_COMPLICATED_NULLNESS __buf, size_t __size, const char* _Nonnull __fmt, ...) __printflike(3, 4);
C/C++:       |     ^        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
C/C++: /Users/ilia/Library/Android/sdk/ndk/27.1.12297006/toolchains/llvm/prebuilt/darwin-x86_64/sysroot/usr/include/bits/fortify/stdio.h:77:5: note: candidate function not viable: 1st argument ('const value_type *' (aka 'const char *')) would lose const qualifier
C/C++:    77 | int snprintf(char* const __BIONIC_COMPLICATED_NULLNESS __pass_object_size dest, size_t size, const char* _Nonnull format, ...)
C/C++:       |     ^        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
C/C++: /Users/User/node_modules/react-native/ReactCommon/jsi/jsi/jsi.cpp:69:15: warning: decomposition declarations are a C++17 extension [-Wc++17-extensions]
C/C++:    69 |     for (auto [_, entry] : runtimeMapIt->second) {
C/C++:       |               ^~~~~~~~~~
C/C++: /Users/User/node_modules/react-native/ReactCommon/jsi/jsi/jsi.cpp:425:7: warning: 'if' initialization statements are a C++17 extension [-Wc++17-extensions]
C/C++:   425 |   if (auto it = runtimeDataGlobal.dataMap_.find(this);
C/C++:       |       ^
C/C++: /Users/User/node_modules/react-native/ReactCommon/jsi/jsi/jsi.cpp:428:9: warning: 'if' initialization statements are a C++17 extension [-Wc++17-extensions]
C/C++:   428 |     if (auto entryIt = map.find(uuid); entryIt != map.end()) {
C/C++:       |         ^
C/C++: /Users/User/node_modules/react-native/ReactCommon/jsi/jsi/jsi.cpp:465:7: warning: 'if' initialization statements are a C++17 extension [-Wc++17-extensions]
C/C++:   465 |   if (auto runtimeMapIt = runtimeDataGlobal.dataMap_.find(this);
C/C++:       |       ^
C/C++: /Users/User/node_modules/react-native/ReactCommon/jsi/jsi/jsi.cpp:467:9: warning: 'if' initialization statements are a C++17 extension [-Wc++17-extensions]
C/C++:   467 |     if (auto customDataIt = runtimeMapIt->second.find(uuid);
C/C++:       |         ^
C/C++: 5 warnings and 1 error generated.

[Incubating] Problems report is available at: file:///Users/User/android/build/reports/problems/problems-report.html

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':react-native-quick-md5:buildCMakeRelWithDebInfo[arm64-v8a]'.
> com.android.ide.common.process.ProcessException: ninja: Entering directory `/Users/User/node_modules/react-native-quick-md5/android/.cxx/RelWithDebInfo/3xx3v2w6/arm64-v8a'
  [1/5] Building CXX object CMakeFiles/quickmd5.dir/cpp-adapter.cpp.o
  FAILED: CMakeFiles/quickmd5.dir/cpp-adapter.cpp.o 
  /Users/ilia/Library/Android/sdk/ndk/27.1.12297006/toolchains/llvm/prebuilt/darwin-x86_64/bin/clang++ --target=aarch64-none-linux-android21 --sysroot=/Users/ilia/Library/Android/sdk/ndk/27.1.12297006/toolchains/llvm/prebuilt/darwin-x86_64/sysroot -Dquickmd5_EXPORTS -I/Users/User/node_modules/react-native-quick-md5/android/../cpp -I/Users/User/node_modules/react-native/React -I/Users/User/node_modules/react-native/React/Base -I/Users/User/node_modules/react-native/ReactCommon/jsi -g -DANDROID -fdata-sections -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes -D__BIONIC_NO_PAGE_SIZE_MACRO -D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security  -O2 -frtti -fexceptions -Wall -fstack-protector-all -O2 -g -DNDEBUG -fPIC -std=gnu++14 -MD -MT CMakeFiles/quickmd5.dir/cpp-adapter.cpp.o -MF CMakeFiles/quickmd5.dir/cpp-adapter.cpp.o.d -o CMakeFiles/quickmd5.dir/cpp-adapter.cpp.o -c /Users/User/node_modules/react-native-quick-md5/android/cpp-adapter.cpp
  In file included from /Users/User/node_modules/react-native-quick-md5/android/cpp-adapter.cpp:2:
  In file included from /Users/User/node_modules/react-native-quick-md5/android/../cpp/quick-md5.h:1:
  In file included from /Users/User/node_modules/react-native/ReactCommon/jsi/jsi/jsilib.h:10:
  /Users/User/node_modules/react-native/ReactCommon/jsi/jsi/jsi.h:79:5: error: no matching function for call to 'snprintf'
     79 |     std::snprintf(
        |     ^~~~~~~~~~~~~
  /Users/ilia/Library/Android/sdk/ndk/27.1.12297006/toolchains/llvm/prebuilt/darwin-x86_64/sysroot/usr/include/stdio.h:286:5: note: candidate function not viable: 1st argument ('const value_type *' (aka 'const char *')) would lose const qualifier
    286 | int snprintf(char* __BIONIC_COMPLICATED_NULLNESS __buf, size_t __size, const char* _Nonnull __fmt, ...) __printflike(3, 4);
        |     ^        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  /Users/ilia/Library/Android/sdk/ndk/27.1.12297006/toolchains/llvm/prebuilt/darwin-x86_64/sysroot/usr/include/bits/fortify/stdio.h:77:5: note: candidate function not viable: 1st argument ('const value_type *' (aka 'const char *')) would lose const qualifier
     77 | int snprintf(char* const __BIONIC_COMPLICATED_NULLNESS __pass_object_size dest, size_t size, const char* _Nonnull format, ...)
        |     ^        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  1 error generated.
  [2/5] Building CXX object CMakeFiles/quickmd5.dir/Users/User/node_modules/react-native-quick-md5/cpp/quick-md5.cpp.o
  FAILED: CMakeFiles/quickmd5.dir/Users/User/node_modules/react-native-quick-md5/cpp/quick-md5.cpp.o 
  /Users/ilia/Library/Android/sdk/ndk/27.1.12297006/toolchains/llvm/prebuilt/darwin-x86_64/bin/clang++ --target=aarch64-none-linux-android21 --sysroot=/Users/ilia/Library/Android/sdk/ndk/27.1.12297006/toolchains/llvm/prebuilt/darwin-x86_64/sysroot -Dquickmd5_EXPORTS -I/Users/User/node_modules/react-native-quick-md5/android/../cpp -I/Users/User/node_modules/react-native/React -I/Users/User/node_modules/react-native/React/Base -I/Users/User/node_modules/react-native/ReactCommon/jsi -g -DANDROID -fdata-sections -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes -D__BIONIC_NO_PAGE_SIZE_MACRO -D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security  -O2 -frtti -fexceptions -Wall -fstack-protector-all -O2 -g -DNDEBUG -fPIC -std=gnu++14 -MD -MT CMakeFiles/quickmd5.dir/Users/User/node_modules/react-native-quick-md5/cpp/quick-md5.cpp.o -MF CMakeFiles/quickmd5.dir/Users/User/node_modules/react-native-quick-md5/cpp/quick-md5.cpp.o.d -o CMakeFiles/quickmd5.dir/Users/User/node_modules/react-native-quick-md5/cpp/quick-md5.cpp.o -c /Users/User/node_modules/react-native-quick-md5/cpp/quick-md5.cpp
  In file included from /Users/User/node_modules/react-native-quick-md5/cpp/quick-md5.cpp:1:
  In file included from /Users/User/node_modules/react-native-quick-md5/cpp/quick-md5.h:1:
  In file included from /Users/User/node_modules/react-native/ReactCommon/jsi/jsi/jsilib.h:10:
  /Users/User/node_modules/react-native/ReactCommon/jsi/jsi/jsi.h:79:5: error: no matching function for call to 'snprintf'
     79 |     std::snprintf(
        |     ^~~~~~~~~~~~~
  /Users/ilia/Library/Android/sdk/ndk/27.1.12297006/toolchains/llvm/prebuilt/darwin-x86_64/sysroot/usr/include/stdio.h:286:5: note: candidate function not viable: 1st argument ('const value_type *' (aka 'const char *')) would lose const qualifier
    286 | int snprintf(char* __BIONIC_COMPLICATED_NULLNESS __buf, size_t __size, const char* _Nonnull __fmt, ...) __printflike(3, 4);
        |     ^        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  /Users/ilia/Library/Android/sdk/ndk/27.1.12297006/toolchains/llvm/prebuilt/darwin-x86_64/sysroot/usr/include/bits/fortify/stdio.h:77:5: note: candidate function not viable: 1st argument ('const value_type *' (aka 'const char *')) would lose const qualifier
     77 | int snprintf(char* const __BIONIC_COMPLICATED_NULLNESS __pass_object_size dest, size_t size, const char* _Nonnull format, ...)
        |     ^        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  1 error generated.
  [3/5] Building CXX object CMakeFiles/quickmd5.dir/Users/User/node_modules/react-native/ReactCommon/jsi/jsi/jsi.cpp.o
  FAILED: CMakeFiles/quickmd5.dir/Users/User/node_modules/react-native/ReactCommon/jsi/jsi/jsi.cpp.o 
  /Users/ilia/Library/Android/sdk/ndk/27.1.12297006/toolchains/llvm/prebuilt/darwin-x86_64/bin/clang++ --target=aarch64-none-linux-android21 --sysroot=/Users/ilia/Library/Android/sdk/ndk/27.1.12297006/toolchains/llvm/prebuilt/darwin-x86_64/sysroot -Dquickmd5_EXPORTS -I/Users/User/node_modules/react-native-quick-md5/android/../cpp -I/Users/User/node_modules/react-native/React -I/Users/User/node_modules/react-native/React/Base -I/Users/User/node_modules/react-native/ReactCommon/jsi -g -DANDROID -fdata-sections -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes -D__BIONIC_NO_PAGE_SIZE_MACRO -D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security  -O2 -frtti -fexceptions -Wall -fstack-protector-all -O2 -g -DNDEBUG -fPIC -std=gnu++14 -MD -MT CMakeFiles/quickmd5.dir/Users/User/node_modules/react-native/ReactCommon/jsi/jsi/jsi.cpp.o -MF CMakeFiles/quickmd5.dir/Users/User/node_modules/react-native/ReactCommon/jsi/jsi/jsi.cpp.o.d -o CMakeFiles/quickmd5.dir/Users/User/node_modules/react-native/ReactCommon/jsi/jsi/jsi.cpp.o -c /Users/User/node_modules/react-native/ReactCommon/jsi/jsi/jsi.cpp
  In file included from /Users/User/node_modules/react-native/ReactCommon/jsi/jsi/jsi.cpp:15:
  In file included from /Users/User/node_modules/react-native/ReactCommon/jsi/jsi/instrumentation.h:16:
  /Users/User/node_modules/react-native/ReactCommon/jsi/jsi/jsi.h:79:5: error: no matching function for call to 'snprintf'
     79 |     std::snprintf(
        |     ^~~~~~~~~~~~~
  /Users/ilia/Library/Android/sdk/ndk/27.1.12297006/toolchains/llvm/prebuilt/darwin-x86_64/sysroot/usr/include/stdio.h:286:5: note: candidate function not viable: 1st argument ('const value_type *' (aka 'const char *')) would lose const qualifier
    286 | int snprintf(char* __BIONIC_COMPLICATED_NULLNESS __buf, size_t __size, const char* _Nonnull __fmt, ...) __printflike(3, 4);
        |     ^        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  /Users/ilia/Library/Android/sdk/ndk/27.1.12297006/toolchains/llvm/prebuilt/darwin-x86_64/sysroot/usr/include/bits/fortify/stdio.h:77:5: note: candidate function not viable: 1st argument ('const value_type *' (aka 'const char *')) would lose const qualifier
     77 | int snprintf(char* const __BIONIC_COMPLICATED_NULLNESS __pass_object_size dest, size_t size, const char* _Nonnull format, ...)
        |     ^        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  /Users/User/node_modules/react-native/ReactCommon/jsi/jsi/jsi.cpp:69:15: warning: decomposition declarations are a C++17 extension [-Wc++17-extensions]
     69 |     for (auto [_, entry] : runtimeMapIt->second) {
        |               ^~~~~~~~~~
  /Users/User/node_modules/react-native/ReactCommon/jsi/jsi/jsi.cpp:425:7: warning: 'if' initialization statements are a C++17 extension [-Wc++17-extensions]
    425 |   if (auto it = runtimeDataGlobal.dataMap_.find(this);
        |       ^
  /Users/User/node_modules/react-native/ReactCommon/jsi/jsi/jsi.cpp:428:9: warning: 'if' initialization statements are a C++17 extension [-Wc++17-extensions]
    428 |     if (auto entryIt = map.find(uuid); entryIt != map.end()) {
        |         ^
  /Users/User/node_modules/react-native/ReactCommon/jsi/jsi/jsi.cpp:465:7: warning: 'if' initialization statements are a C++17 extension [-Wc++17-extensions]
    465 |   if (auto runtimeMapIt = runtimeDataGlobal.dataMap_.find(this);
        |       ^
  /Users/User/node_modules/react-native/ReactCommon/jsi/jsi/jsi.cpp:467:9: warning: 'if' initialization statements are a C++17 extension [-Wc++17-extensions]
    467 |     if (auto customDataIt = runtimeMapIt->second.find(uuid);
        |         ^
  5 warnings and 1 error generated.
  [4/5] Building CXX object CMakeFiles/quickmd5.dir/Users/User/node_modules/react-native-quick-md5/cpp/md5.cpp.o
  ninja: build stopped: subcommand failed.
  
  C++ build system [build] failed while executing:
      /Users/ilia/Library/Android/sdk/cmake/3.22.1/bin/ninja \
        -C \
        /Users/User/node_modules/react-native-quick-md5/android/.cxx/RelWithDebInfo/3xx3v2w6/arm64-v8a \
        quickmd5
    from /Users/User/node_modules/react-native-quick-md5/android
```